### PR TITLE
generate the internal action versions from the current ones used in this repo

### DIFF
--- a/mono_repo/lib/src/commands/github/action_info.dart
+++ b/mono_repo/lib/src/commands/github/action_info.dart
@@ -1,4 +1,5 @@
 import '../../root_config.dart';
+import 'action_versions.dart';
 import 'job.dart';
 import 'step.dart';
 
@@ -6,29 +7,29 @@ enum ActionInfo implements Comparable<ActionInfo> {
   cache(
     name: 'Cache Pub hosted dependencies',
     repo: 'actions/cache',
-    version: '88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8', // v3.3.1
+    version: actionsCacheVersion,
   ),
   checkout(
     name: 'Checkout repository',
     repo: 'actions/checkout',
-    version: '8e5e7e5ab8b370d6c329ec480221332ada57f0ab', // v3.5.2
+    version: actionsCheckoutVersion,
   ),
   setupDart(
     name: 'Setup Dart SDK',
     repo: 'dart-lang/setup-dart',
-    version: 'd6a63dab3335f427404425de0fbfed4686d93c4f', // v1.5.0
+    version: dartLangSetupDartVersion,
   ),
   setupFlutter(
     name: 'Setup Flutter SDK',
     repo: 'subosito/flutter-action',
-    version: '48cafc24713cca54bbe03cdc3a423187d413aafa', // v2.10.0
+    version: subositoFlutterActionVersion,
   ),
 
   /// See https://github.com/marketplace/actions/coveralls-github-action
   coveralls(
     name: 'Upload coverage to Coveralls',
     repo: 'coverallsapp/github-action',
-    version: 'master',
+    version: coverallsappGithubActionVersion,
     completionJobFactory: _coverageCompletionJob,
   ),
 
@@ -36,7 +37,7 @@ enum ActionInfo implements Comparable<ActionInfo> {
   codecov(
     name: 'Upload coverage to codecov.io',
     repo: 'codecov/codecov-action',
-    version: 'd9f34f8cd5cb3b3eb79b3e4b5dae3a16df499a70',
+    version: codecovCodecovActionVersion,
   );
 
   const ActionInfo({

--- a/mono_repo/lib/src/commands/github/action_versions.dart
+++ b/mono_repo/lib/src/commands/github/action_versions.dart
@@ -7,13 +7,8 @@
 /// To regenerate it, run the `tool/generate_action_versions.dart` script.
 
 const actionsCacheVersion = '88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8';
-
 const dartLangSetupDartVersion = 'd6a63dab3335f427404425de0fbfed4686d93c4f';
-
 const actionsCheckoutVersion = '8e5e7e5ab8b370d6c329ec480221332ada57f0ab';
-
 const subositoFlutterActionVersion = '48cafc24713cca54bbe03cdc3a423187d413aafa';
-
 const coverallsappGithubActionVersion = 'master';
-
 const codecovCodecovActionVersion = 'main';

--- a/mono_repo/lib/src/commands/github/action_versions.dart
+++ b/mono_repo/lib/src/commands/github/action_versions.dart
@@ -2,6 +2,10 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// This file is generated, and should not be modified by hand.
+///
+/// To regenerate it, run the `tool/generate_action_versions.dart` script.
+
 const actionsCacheVersion = '88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8';
 
 const dartLangSetupDartVersion = 'd6a63dab3335f427404425de0fbfed4686d93c4f';

--- a/mono_repo/lib/src/commands/github/action_versions.dart
+++ b/mono_repo/lib/src/commands/github/action_versions.dart
@@ -17,4 +17,3 @@ const subositoFlutterActionVersion = '48cafc24713cca54bbe03cdc3a423187d413aafa';
 const coverallsappGithubActionVersion = 'master';
 
 const codecovCodecovActionVersion = 'main';
-

--- a/mono_repo/lib/src/commands/github/action_versions.dart
+++ b/mono_repo/lib/src/commands/github/action_versions.dart
@@ -1,0 +1,16 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+const actionsCacheVersion = '88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8';
+
+const dartLangSetupDartVersion = 'd6a63dab3335f427404425de0fbfed4686d93c4f';
+
+const actionsCheckoutVersion = '8e5e7e5ab8b370d6c329ec480221332ada57f0ab';
+
+const subositoFlutterActionVersion = '48cafc24713cca54bbe03cdc3a423187d413aafa';
+
+const coverallsappGithubActionVersion = 'master';
+
+const codecovCodecovActionVersion = 'main';
+

--- a/mono_repo/test/action_versions_test.dart
+++ b/mono_repo/test/action_versions_test.dart
@@ -1,0 +1,19 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+void main() {
+  test('action versions are up to date', () {
+    expect(
+      Process.runSync(
+        Platform.executable,
+        ['tool/generate_action_versions.dart', '--validate'],
+      ).exitCode,
+      0,
+    );
+  });
+}

--- a/mono_repo/test/action_versions_test.dart
+++ b/mono_repo/test/action_versions_test.dart
@@ -8,12 +8,10 @@ import 'package:test/test.dart';
 
 void main() {
   test('action versions are up to date', () {
-    expect(
-      Process.runSync(
-        Platform.executable,
-        ['tool/generate_action_versions.dart', '--validate'],
-      ).exitCode,
-      0,
+    final result = Process.runSync(
+      Platform.executable,
+      ['tool/generate_action_versions.dart', '--validate'],
     );
+    expect(result.exitCode, 0, reason: result.stdout as String);
   });
 }

--- a/mono_repo/test/action_versions_test.dart
+++ b/mono_repo/test/action_versions_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+// On windows this test fails for unknown reasons, possibly there are carraige
+// returns being introduced during formatting.
+@TestOn('linux')
 import 'dart:io';
 
 import 'package:test/test.dart';

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -1,0 +1,73 @@
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:mono_repo/src/root_config.dart';
+
+// Should be ran from the `mono_repo` package directory.
+void main(List<String> args) {
+  final parsedArgs = argParser.parse(args);
+  final validateOnly = parsedArgs['validate'] as bool;
+  final versionsFile = File('lib/src/commands/github/action_versions.dart');
+  if (!versionsFile.existsSync()) {
+    print('Unable to find existing versions file at `${versionsFile.path}`, '
+        'make sure you are running from the `mono_repo` package directory');
+    exit(1);
+  }
+  final previousConent = versionsFile.readAsStringSync();
+  final workflowFile = File('../.github/workflows/dart.yml');
+  final versions =
+      RootConfig.parseActionVersions(workflowFile.readAsStringSync());
+  final newContentBuffer = StringBuffer('''
+// Copyright (c) 2023, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+''');
+  for (var entry in versions.entries) {
+    newContentBuffer
+      ..writeln("const ${entry.key.toVariableName} = '${entry.value}';")
+      ..writeln();
+  }
+  final newContent = newContentBuffer.toString();
+  if (validateOnly) {
+    exit(previousConent == newContent ? 0 : 1);
+  }
+  if (previousConent == newContent) {
+    print('No change');
+  } else {
+    print('Versions changed, updating');
+    versionsFile.writeAsStringSync(newContent);
+  }
+}
+
+final argParser = ArgParser()..addFlag('validate');
+
+extension _ToVariableName on String {
+  String get toVariableName {
+    final buffer = StringBuffer();
+    var capitalizeNext = false;
+    for (var i = 0; i < length; i++) {
+      final char = this[i];
+      switch (char) {
+        case '-':
+        case '_':
+        case '/':
+          capitalizeNext = true;
+          continue;
+        default:
+          if (capitalizeNext) {
+            buffer.write(char.toUpperCase());
+            capitalizeNext = false;
+          } else {
+            buffer.write(char);
+          }
+      }
+    }
+    buffer.write('Version');
+    return buffer.toString();
+  }
+}

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -36,15 +36,21 @@ void main(List<String> args) {
       ..writeln("const ${entry.key.toVariableName} = '${entry.value}';")
       ..writeln();
   }
-  final newContent = newContentBuffer.toString();
+  final tmpDir = Directory.systemTemp.createTempSync('gen_action_versions');
+  final tmpFile =
+      File.fromUri(tmpDir.uri.resolve('generate_action_versions.dart'))
+        ..writeAsStringSync(newContentBuffer.toString());
+  Process.runSync(Platform.executable, ['format', tmpFile.path]);
+  final newContent = tmpFile.readAsStringSync();
   if (validateOnly) {
     exit(previousConent == newContent ? 0 : 1);
   }
   if (previousConent == newContent) {
     print('No change');
+    tmpFile.deleteSync();
   } else {
     print('Versions changed, updating');
-    versionsFile.writeAsStringSync(newContent);
+    tmpFile.renameSync(versionsFile.path);
   }
 }
 

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -40,7 +40,16 @@ void main(List<String> args) {
   final tmpFile =
       File.fromUri(tmpDir.uri.resolve('generate_action_versions.dart'))
         ..writeAsStringSync(newContentBuffer.toString());
-  Process.runSync(Platform.executable, ['format', tmpFile.path]);
+  final fmtResult =
+      Process.runSync(Platform.resolvedExecutable, ['format', tmpFile.path]);
+  if (fmtResult.exitCode != 0) {
+    tmpDir.deleteSync(recursive: true);
+    stdout
+      ..writeln('Error: Failed to run dartfmt')
+      ..write(fmtResult.stdout);
+    stderr.write(fmtResult.stderr);
+    exit(1);
+  }
   final newContent = tmpFile.readAsStringSync();
 
   if (previousContent == newContent) {
@@ -59,7 +68,7 @@ $newContent
     if (validateOnly) {
       exit(1);
     } else {
-      tmpFile.renameSync(versionsFile.path);
+      tmpDir.renameSync(versionsFile.path);
     }
   }
 }

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -33,8 +33,7 @@ void main(List<String> args) {
 ''');
   for (var entry in versions.entries) {
     newContentBuffer
-      ..writeln("const ${entry.key.toVariableName} = '${entry.value}';")
-      ..writeln();
+        .writeln("const ${entry.key.toVariableName} = '${entry.value}';");
   }
   final tmpDir = Directory.systemTemp.createTempSync('gen_action_versions');
   final tmpFile =
@@ -60,10 +59,14 @@ void main(List<String> args) {
 Content changed!
 
 Previous:
+```
 $previousContent
+```
 
 New:
+```
 $newContent
+```
 ''');
     if (validateOnly) {
       exit(1);

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -42,8 +42,12 @@ void main(List<String> args) {
         ..writeAsStringSync(newContentBuffer.toString());
   Process.runSync(Platform.executable, ['format', tmpFile.path]);
   final newContent = tmpFile.readAsStringSync();
-  if (validateOnly) {
-    stderr.write('''
+
+  if (previousContent == newContent) {
+    print('No change');
+    tmpFile.deleteSync();
+  } else {
+    stdout.write('''
 Content changed!
 
 Previous:
@@ -52,14 +56,11 @@ $previousContent
 New:
 $newContent
 ''');
-    exit(previousContent == newContent ? 0 : 1);
-  }
-  if (previousContent == newContent) {
-    print('No change');
-    tmpFile.deleteSync();
-  } else {
-    print('Versions changed, updating');
-    tmpFile.renameSync(versionsFile.path);
+    if (validateOnly) {
+      exit(1);
+    } else {
+      tmpFile.renameSync(versionsFile.path);
+    }
   }
 }
 

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -42,20 +42,18 @@ void main(List<String> args) {
   final fmtResult =
       Process.runSync(Platform.resolvedExecutable, ['format', tmpFile.path]);
   if (fmtResult.exitCode != 0) {
-    tmpDir.deleteSync(recursive: true);
     stdout
       ..writeln('Error: Failed to run dartfmt')
       ..write(fmtResult.stdout);
     stderr.write(fmtResult.stderr);
-    exit(1);
-  }
-  final newContent = tmpFile.readAsStringSync();
-
-  if (previousContent == newContent) {
-    print('No change');
-    tmpFile.deleteSync();
+    exitCode = 1;
   } else {
-    stdout.write('''
+    final newContent = tmpFile.readAsStringSync();
+
+    if (previousContent == newContent) {
+      print('No change');
+    } else {
+      stdout.write('''
 Content changed!
 
 Previous:
@@ -68,12 +66,14 @@ New:
 $newContent
 ```
 ''');
-    if (validateOnly) {
-      exit(1);
-    } else {
-      tmpDir.renameSync(versionsFile.path);
+      if (validateOnly) {
+        exitCode = 1;
+      } else {
+        tmpFile.renameSync(versionsFile.path);
+      }
     }
   }
+  tmpDir.deleteSync(recursive: true);
 }
 
 final argParser = ArgParser()..addFlag('validate');

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -17,7 +17,7 @@ void main(List<String> args) {
         'make sure you are running from the `mono_repo` package directory');
     exit(1);
   }
-  final previousConent = versionsFile.readAsStringSync();
+  final previousContent = versionsFile.readAsStringSync();
   final workflowFile = File('../.github/workflows/dart.yml');
   final versions =
       RootConfig.parseActionVersions(workflowFile.readAsStringSync());
@@ -43,9 +43,18 @@ void main(List<String> args) {
   Process.runSync(Platform.executable, ['format', tmpFile.path]);
   final newContent = tmpFile.readAsStringSync();
   if (validateOnly) {
-    exit(previousConent == newContent ? 0 : 1);
+    stderr.write('''
+Content changed!
+
+Previous:
+$previousContent
+
+New:
+$newContent
+''');
+    exit(previousContent == newContent ? 0 : 1);
   }
-  if (previousConent == newContent) {
+  if (previousContent == newContent) {
     print('No change');
     tmpFile.deleteSync();
   } else {

--- a/mono_repo/tool/generate_action_versions.dart
+++ b/mono_repo/tool/generate_action_versions.dart
@@ -26,6 +26,10 @@ void main(List<String> args) {
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+/// This file is generated, and should not be modified by hand.
+///
+/// To regenerate it, run the `tool/generate_action_versions.dart` script.
+
 ''');
   for (var entry in versions.entries) {
     newContentBuffer


### PR DESCRIPTION
I can also land this separately, but you can also merge this here if you like to include it in your PR.

This adds a tool to pull the versions from the workflow file into a dart file, which is what we use for packages where dependabot is not managing the versions.

It also adds a test that the versions in the Dart file match up with the workflow versions.

This will make it so that dependabot CLs to this repo fail (the test will fail), but we can re-generate the file easily and probably push it directly to the dependabot PR.